### PR TITLE
Update HX711-multi.cpp

### DIFF
--- a/HX711-multi.cpp
+++ b/HX711-multi.cpp
@@ -138,12 +138,12 @@ void HX711MULTI::readRaw(long *result) {
 	// pulse the clock pin 24 times to read the data
 	for (i = 0; i < 24; ++i) {
 		digitalWrite(PD_SCK, HIGH);
+		digitalWrite(PD_SCK, LOW);
 		if (NULL!=result) {
 			for (j = 0; j < COUNT; ++j) {
 				bitWrite(result[j], 23-i, digitalRead(DOUT[j]));
 			}
-		}
-		digitalWrite(PD_SCK, LOW);
+		}		
 	}
    
 	// set the channel and the gain factor for the next reading using the clock pin


### PR DESCRIPTION
I was trying to use this library to measure 12 load cells with 12 hx711 modules. This library was working fine up to 4 load cells and modules, but oddly when I was trying to measure more than 5 load cells, it was not working. Then I decided to write my own code to read the signals and I found out what is wrong with this library: the HX711 datasheet clearly says that PD_SCK high time should not exceed 50 us, so as the numbers of load cells increase you pass the limit. The solution is so simple: you just have to write the results in PD_SCK low time which does not have limits.

![image](https://user-images.githubusercontent.com/79404636/140638609-49ddb09c-fc40-4a67-aea2-8e8e05ada14a.png)

now it works for me fine with 12x HX711 and is not limited to that.

![image](https://user-images.githubusercontent.com/79404636/140638694-5caca49d-2568-4ec8-8e17-fb97e37a979e.png)
